### PR TITLE
Build against Boost's master branch

### DIFF
--- a/tools/travis_install.sh
+++ b/tools/travis_install.sh
@@ -32,7 +32,8 @@ if [ "$SELF" == "interval" ]; then
     export SELF=numeric/interval
 fi
 if [ "$TRAVIS_BRANCH" == "develop" ]; then
-    export BOOST_BRANCH="develop"
+# should be: export BOOST_BRANCH="develop", but currently autodiff exists in the Boost.Math develop branch
+    export BOOST_BRANCH="master"
 else
     export BOOST_BRANCH="master"
 fi


### PR DESCRIPTION
Use $BOOST_BRANCH="master" until workflow can be established to allow for working against $BOOST_BRANCH="develop", since we're right now going to collide with the autodiff version existing in Boost.Math's develop branch.