### PR TITLE
Feature/ftuple

### DIFF
--- a/example/mixed_partials.cpp
+++ b/example/mixed_partials.cpp
@@ -5,14 +5,18 @@
 
 #include <boost/lexical_cast.hpp>
 #include <boost/math/differentiation/autodiff.hpp>
+#include <boost/mp11/tuple.hpp>
+#include <boost/mp11/utility.hpp>
 #include <boost/multiprecision/cpp_bin_float.hpp>
 #include <iostream>
 
 using namespace boost::math::differentiation;
 
-auto f = [](const auto& w, const auto& x, const auto& y, const auto& z)
-{
+struct f {
+  template<typename W, typename X, typename Y, typename Z>
+  promote<W, X, Y, Z> operator()(const W& w, const X& x, const Y& y, const Z& z) const {
     return exp(w*sin(x*log(y)/z) + sqrt(w*z/(x*y))) + w*w/tan(z);
+  }
 };
 
 // Derivatives calculated from symbolic differentiation by Mathematica for comparison. Script: mixed_partials.nb
@@ -25,7 +29,7 @@ int main() {
   constexpr std::size_t Ny = 4; // Max order of derivative to calculate for y
   constexpr std::size_t Nz = 3; // Max order of derivative to calculate for z
   const auto variables = make_ftuple<type,Nw,Nx,Ny,Nz>(11,12,13,14);
-  const auto v = std::apply(f, variables);
+  const auto v = boost::mp11::tuple_apply(f{}, variables);
   std::size_t ia = 0;
   double max_relative_error = 0;
   for (std::size_t iw = 0; iw <= Nw; ++iw)

--- a/include/boost/math/differentiation/autodiff.hpp
+++ b/include/boost/math/differentiation/autodiff.hpp
@@ -13,6 +13,7 @@
 #include <boost/math/constants/constants.hpp>
 #include <boost/math/special_functions.hpp>
 #include <boost/math/tools/promotion.hpp>
+#include <boost/mp11/integer_sequence.hpp>
 #include <boost/multiprecision/rational_adaptor.hpp>
 
 #include <algorithm>
@@ -576,22 +577,22 @@ template <size_t>
 struct zero : std::integral_constant<size_t,0> {};
 
 template<typename RealType, size_t Order, size_t... Is>
-auto make_fvar_for_tuple(std::index_sequence<Is...>, const RealType& ca) {
+auto make_fvar_for_tuple(mp11::index_sequence<Is...>, const RealType& ca) -> decltype(make_fvar<RealType,zero<Is>::value...,Order>(ca)) {
   return make_fvar<RealType,zero<Is>::value...,Order>(ca);
 }
 
 template<typename RealType, size_t... Orders, size_t... Is, typename... RealTypes>
-auto make_ftuple(std::index_sequence<Is...>, const RealTypes&... ca) {
-  return std::make_tuple(make_fvar_for_tuple<RealType,Orders>(std::make_index_sequence<Is>{},ca)...);
+auto make_ftuple(mp11::index_sequence<Is...>, const RealTypes&... ca) -> decltype(std::make_tuple(make_fvar_for_tuple<RealType,Orders>(mp11::make_index_sequence<Is>{},ca)...)) {
+  return std::make_tuple(make_fvar_for_tuple<RealType,Orders>(mp11::make_index_sequence<Is>{},ca)...);
 }
 
 } // namespace detail
 
 template<typename RealType, size_t... Orders, typename... RealTypes>
-auto make_ftuple(const RealTypes&... ca) {
+auto make_ftuple(const RealTypes&... ca) -> decltype(detail::make_ftuple<RealType,Orders...>(mp11::index_sequence_for<RealTypes...>{}, ca...)) {
   static_assert(sizeof...(Orders) == sizeof...(RealTypes),
     "Number of Orders must match number of function parameters.");
-  return detail::make_ftuple<RealType,Orders...>(std::index_sequence_for<RealTypes...>{}, ca...);
+  return detail::make_ftuple<RealType,Orders...>(mp11::index_sequence_for<RealTypes...>{}, ca...);
 }
 
 namespace detail {


### PR DESCRIPTION
Replaced `std::apply`, `std::index_sequence`, and `std::make_index_sequence` with `mp11::tuple_apply`, `mp11::index_sequence` and `mp11::make_index_sequence`. I also added trailing return types for the new functions returning `auto`; hopefully return types or aliases can replace the `auto`s, so the trailing return types can go away.